### PR TITLE
refactor(editor.config) Обновлён editor.config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,12 +3,10 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
-indent_style = tab
+indent_size = 2
+indent_style = space
 trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
 
-[{*.json,*.yml}]
-indent_size = 2


### PR DESCRIPTION
  - Editor.config приведён в соответствие с настройками Prettier.
  - В качестве символа табуляции установлен пробел.
  - Размер отступа унифицирован до двух пробелов.

Поскольку данные настройки являются универсальными, специфические переопределения для файлов .json и .yml являются избыточными и удалены, это упрощает конфигурацию и предотвращает возможные конфликты.